### PR TITLE
Last month data should be accurate using last 30 days, not since current date of last month

### DIFF
--- a/internal/services/stats_service.go
+++ b/internal/services/stats_service.go
@@ -75,7 +75,7 @@ func (s *StatsService) UserDayWeekMonthViewsStatsMap(ctx context.Context, userID
 	rows, err := s.repository.Queries().ProfileHourlyViewsStats(ctx, dbs.ProfileHourlyViewsStatsParams{
 		Day:     now.AddDate(0, 0, -1),
 		Week:    now.AddDate(0, 0, -7),
-		Month:   now.AddDate(0, -1, 0),
+		Month:   now.AddDate(0, 0, -30),
 		UserIds: userIDs,
 	})
 	if err != nil {


### PR DESCRIPTION
The view count for last month should be last 30 days, not since current date last month because the days in a month varies from 28 (February) to 31 (January, March, May, July, August, October, and December).