### PR TITLE
Improvements to GitHub CI

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,6 +1,7 @@
-name: Run tests and increment version
+name: Run tests
 
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -9,6 +10,9 @@ jobs:
   code-quality:
     name: Code quality
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.21', '1.22' ]
     steps:
       - name: Checkout
         uses: actions/checkout@master
@@ -16,10 +20,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: ${{ matrix.go-version }}
 
       - name: Run go vet
         run: go vet ./...
 
       - name: Unit tests
-        run: go test $(go list ./... | grep -v '/integrationtest') -v
+        run: go test -v ./...


### PR DESCRIPTION
Several minor improvements to the GitHub CI workflow:

- more descriptive `name` (there is no automatic version increment);
- workflow is invoked on `pull_request` (on `push` may be too late if a non-compiling PR is merged);
- allowing support for different Go version (the case is the release of `1.22` - the `go.mod` specifies `1.21`, but the +1 minor version is supported according to the official Go standard, so we support both versions);
- dropping the mention of the `integrationtest` directory (`find . -name 'integrationtest'` in root gives nothing).